### PR TITLE
[Chore]: Add reusable workflow for NPM config

### DIFF
--- a/.github/workflows/reusable-workflow__npm-configure-techuser-token.yaml
+++ b/.github/workflows/reusable-workflow__npm-configure-techuser-token.yaml
@@ -1,0 +1,17 @@
+name: Configure NPM for tech user github token
+
+on:
+  workflow_call:
+    secrets:
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+jobs:
+  reusable_workflow_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure NPM - set github token for tech user and registry
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.LA_TECH_USER_AUTH_TOKEN}}" >> .npmrc
+          echo "@spring-media:registry=https://npm.pkg.github.com" >> .npmrc
+     env:
+        GITHUB_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}


### PR DESCRIPTION
## What does this change?
This adds a reusable workflow for setting NPM config for the la tech user.

* sets registry
* sets github token

## Why?
Whenever we want to work with la-frontend-utils we need to set this in the GA so that the project can be build. We do not want to copy everything everytime. this would be error prone.
