### PR TITLE
Chore: Add reusable frontend lint and test workflow

### DIFF
--- a/.github/workflows/reusable-workflow__js__format-lint-test.yml
+++ b/.github/workflows/reusable-workflow__js__format-lint-test.yml
@@ -1,0 +1,40 @@
+name: Format check, linting and unit tests
+
+on:
+  workflow_call:
+    secrets:
+      NPM_AUTH_TOKEN:
+        required: true
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+
+jobs:
+  format-lint-and-unit-test:
+    name: Run linters and unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          always-auth: true
+          cache: npm
+          registry-url: "https://registry.npmjs.org/"
+      - name: Setup npmrc
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.LA_TECH_USER_AUTH_TOKEN}}" >> .npmrc
+          echo "@spring-media:registry=https://npm.pkg.github.com" >> .npmrc
+        env:
+          LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      - name: Run format check
+        run: npm run format-check
+      - name: Run linters
+        run: npm run lint
+      - name: Run tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -4,12 +4,47 @@ This repo hosts shared github workflows used by other repositories.
 
 Please refer to githubs documentation on how to use and implement shared workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 
-### After Deployment Slack Notification Workflow
+## Workflows
 
-The After Deployment Slack Notification notifies our slack channel `#t_loyalty_notifications` whether a deployment was successful
-or not.
+- [slack-notify-after-production-deploy](#slack-notify-after-production-deploy)
+- [js\_\_format-lint-test](#js__format-lint-test)
+
+### js\_\_format-lint-test
+
+The [js\_\_format-lint-test workflow](./.github/workflows/reusable-workflow__js__format-lint-test.yml) will install dependencies and then run these npm commands on the project:
+
+- `install`
+- `format-check`
+- `lint`
+- `test`
+
+If the projects `package.json` doesn't provide all of these scripts, the workflow will fail.
+
+It also requires to secrets to be passed in:
+
+- `NPM_AUTH_TOKEN`
+- `LA_TECH_USER_AUTH_TOKEN`
+
+The node version has to be set via a `.node-version` file.
 
 #### Usage
+
+```yaml
+jobs:
+  …
+  format-lint-and-unit-test:
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__js__format-lint-test.yml@main
+    secrets:
+      NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+```
+
+### slack-notify-after-production-deploy
+
+The [slack-notify-after-production-deploy workflow](./.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml) notifies our slack channel `#t_loyalty_notifications` whether a deployment was successful or not.
+
+#### Usage
+
 The Slack deployment notification consists of an extra job that needs to be added to your deployment pipeline.
 
 Add the job `inform-slack` to the end(!) of your github actions file.
@@ -23,7 +58,6 @@ The job handles every case, by: `if: ${{ always() }}` it will always run, no mat
 line `needs: [<ADD JOB ID>]` makes it wait until the deployment job has finished (in any way) and
 `success: ${{ needs.<ADD JOB ID>.result == 'success' }}` hands in a boolean, `true` in case the run was successful,
 `false` in case it was a failure, skipped or cancelled.
-
 
 ```yaml
 name: deploy


### PR DESCRIPTION
## What does this change?

Adds a reusable frontend format lint and test workflow

## Why?

So we don't have to repeat ourselves for every frontend project