### PR TITLE
Chore: Shared aws deploy cleanup workflow

### DIFF
--- a/.github/workflows/reusable-workflow__aws-remove-bucket.yaml
+++ b/.github/workflows/reusable-workflow__aws-remove-bucket.yaml
@@ -1,0 +1,26 @@
+name: AWS remove bucket
+
+on:
+  workflow_call:
+    inputs:
+      aws_bucket:
+        required: true
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_ACCESS_KEY_SECRET:
+        required: true
+jobs:
+  RemoveS3Bucket:
+    name: Remove S3 bucket ${{ inputs.aws_bucket }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+          aws-region: eu-central-1
+      - name: Remove the bucket
+        run: aws s3 rm --recursive ${{ inputs.aws_bucket }}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,32 @@ Please refer to githubs documentation on how to use and implement shared workflo
 
 ### Workflows
 
+- [aws-remove-bucket](#aws-remove-bucket)
 - [js\_\_deploy-to-s3](#js__deploy-to-s3)
 - [js\_\_format-lint-test](#js__format-lint-test)
 - [slack-notify-after-production-deploy](#slack-notify-after-production-deploy)
+
+## aws-remove-bucket
+
+[aws-remove-bucket workflow](.github/workflows/reusable-workflow__aws-remove-bucket.yaml) removes a given bucket from S3. We need this for cleanup of branch deploys to S3 buckets after they got merged.
+
+### Usage
+
+```yaml
+
+jobs:
+  …
+  cleanup-after-merge:
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__aws-remove-bucket.yaml@v1
+    with:
+      aws_bucket: s3://hua-mod-web.staging.la.welt.de/${{ github.head_ref || github.ref_name }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
+      AWS_ACCESS_KEY_SECRET: ${{ secrets.access_key_secret }}
+  …
+```
+
+###
 
 ## js\_\_deploy-to-s3
 


### PR DESCRIPTION
## What does this change?

Adds a shared workflow to remove an S3 bucket

## Why?

We need this for cleanup after a branch deploy to an S3 bucket. 