### PR TITLE
Chore: Extend workflow for linting and formatting

### DIFF
--- a/.github/workflows/resusable-workflow_js_format-lint-test-draft.yml
+++ b/.github/workflows/resusable-workflow_js_format-lint-test-draft.yml
@@ -1,0 +1,45 @@
+name: Format check, linting and unit tests
+
+on:
+  workflow_call:
+    secrets:
+      NPM_AUTH_TOKEN:
+        required: true
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+
+jobs:
+  format-lint-and-unit-test:
+    name: Run linters and unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          always-auth: true
+          cache: npm
+          registry-url: "https://registry.npmjs.org/"
+      - name: Setup npmrc
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.LA_TECH_USER_AUTH_TOKEN}}" >> .npmrc
+          echo "@spring-media:registry=https://npm.pkg.github.com" >> .npmrc
+        env:
+          LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+      - name: Install custom dependencies
+        id: install-deps
+        run: npm run install-dependencies
+        continue-on-error: true
+      - name: Install dependencies
+        if: steps.install-deps.outcome != 'success'
+        run: npm install --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      - name: Run format check
+        run: npm run format-check --if-present
+      - name: Run linters
+        run: npm run lint --if-present
+      - name: Run tests
+        run: npm run test --if-present


### PR DESCRIPTION
## What does this change?
It extends the workflow for linting and formatting

## Why?
So we can use `npm run install-dependencies` which is needed for some projects. The issue came up after trying to move LA-Schrotty to github actions

## Link to supporting ticket or Screenshots (if applicable)
https://github.com/spring-media/la-schrotty/pull/14#discussion_r1067240590