### PR TITLE
Chore: New deploy workflow

### DIFF
--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -25,6 +25,9 @@ on:
         required: true
       NPM_AUTH_TOKEN:
         required: true
+      SLACK_BOT_TOKEN:
+        required: false
+        description: Only required when post_slack_notification input is set to true as well
 
 jobs:
   deploy:

--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -1,0 +1,75 @@
+name: Build and deploy
+
+on:
+  workflow_call:
+    inputs:
+      build_script_name:
+        required: true
+        type: string
+        description: The name of the npm script to build the project
+      deploy_script_name:
+        required: true
+        type: string
+        description: The name of the npm script to deploy the project
+      post_slack_notification:
+        required: false
+        type: boolean
+        description: Whether to post a notification on Team LAs Slack. Should be used for production deploys only.
+
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_ACCESS_KEY_SECRET:
+        required: true
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+      NPM_AUTH_TOKEN:
+        required: true
+
+jobs:
+  deploy:
+    name: Build and deploy the project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          always-auth: true
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+      - name: Add github npm registry with scope @spring-media to .npmrc
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.LA_TECH_USER_AUTH_TOKEN}}" >> .npmrc
+          echo "@spring-media:registry=https://npm.pkg.github.com" >> .npmrc
+      - name: Install dependencies
+        run: |
+          npm install --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      - name: Build project
+        run: |
+          npm run clean --if-present
+          npm run ${{ inputs.build_script_name }}
+      - name: Configure AWS creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+          aws-region: eu-central-1
+      - name: Deploy the project
+        run: npm run ${{ inputs.deploy_script_name }}
+  slack-notify-after-production-deploy:
+    needs: deploy
+    if: ${{ inputs.post_slack_notification }}
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml@v1
+    with:
+      workflow: ${{ github.workflow }}
+      repository: ${{ github.repository }}
+      repositoryUrl: ${{ github.event.repository.url }}
+      refName: ${{ github.ref_name }}
+      success: ${{ needs.deploy.result == 'success' }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Please refer to githubs documentation on how to use and implement shared workflo
 ### Workflows
 
 - [aws-remove-bucket](#aws-remove-bucket)
+- [js\_\_build-and-deploy](#js__build-and-deploy)
 - [js\_\_deploy-to-s3](#js__deploy-to-s3)
 - [js\_\_format-lint-test](#js__format-lint-test)
 - [js\_\_run-e2e-tests](#js__run-e2e-tests)
@@ -32,7 +33,49 @@ jobs:
   …
 ```
 
-###
+## js\_\_build-and-deploy
+
+The [js\_\_build-and-deploy workflow](./.github/workflows/reusable-workflow__js__build-and-deploy.yml) runs the given
+build and deploy npm scripts to build and deploy a project
+
+Required parameters
+
+- `build_script_name` (string) – the npm command to execute the build.
+- `deploy_script_name` (string) – the npm command to execute the deploy.
+
+Optional parameters
+
+- `post_slack_notification` (boolean) – Whether to post a notification on Team LAs Slack. Should be set to true on production deploys always.
+
+Required secrets:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_ACCESS_KEY_SECRET`
+- `LA_TECH_USER_AUTH_TOKEN`
+- `NPM_AUTH_TOKEN`
+
+### Usage
+
+```yaml
+jobs:
+  …
+  deploy-branch:
+    needs: format-lint-and-unit-tests
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml@v1
+    with:
+      cloudfront_distribution_id: E26N41SPUCWIRP
+      cloudfront_paths: /
+      build_script_name: build-staging
+      aws_bucket: s3://hua-mod-web.staging.la.welt.de/${{ github.head_ref || github.ref_name }}
+      build_directory: build
+      branch_deploy: true
+      branch_name: ${{ github.head_ref || github.ref_name }}
+      branch_deploy_base_url: https://hua-mod-web.staging.la.welt.de
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
+      AWS_ACCESS_KEY_SECRET: ${{ secrets.access_key_secret }}
+      LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+```
 
 ## js\_\_deploy-to-s3
 


### PR DESCRIPTION
## What does this change?

Adds another deploy workflow

## Why?

We saw that we need more fine grained control over the files being transmitted to S3. Especially setting things like cache time on a per file basis, explicitly setting a charset and so on where used in some projects.
We decided we want to keep the deploy mechanisms defined in a script in respective projects. That way we also keep the ability to deploy a project from the command line more easily (in case Github Actions are not available).

I still think it makes sense to have a shared action that does all the required setup and afterthoughts, like posting a notification on slack.

