### PR TITLE
Chore: Remove slack from deploy workflow

### DIFF
--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -11,10 +11,6 @@ on:
         required: true
         type: string
         description: The name of the npm script to deploy the project
-      post_slack_notification:
-        required: false
-        type: boolean
-        description: Whether to post a notification on Team LAs Slack. Should be used for production deploys only.
 
     secrets:
       AWS_ACCESS_KEY_ID:
@@ -25,9 +21,6 @@ on:
         required: true
       NPM_AUTH_TOKEN:
         required: true
-      SLACK_BOT_TOKEN:
-        required: false
-        description: Only required when post_slack_notification input is set to true as well
 
 jobs:
   deploy:
@@ -62,17 +55,5 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
           aws-region: eu-central-1
-      - name: Deploy the project
+      - name: Run the deploy script
         run: npm run ${{ inputs.deploy_script_name }}
-  slack-notify-after-production-deploy:
-    needs: deploy
-    if: ${{ inputs.post_slack_notification }}
-    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml@v1
-    with:
-      workflow: ${{ github.workflow }}
-      repository: ${{ github.repository }}
-      repositoryUrl: ${{ github.event.repository.url }}
-      refName: ${{ github.ref_name }}
-      success: ${{ needs.deploy.result == 'success' }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -59,21 +59,14 @@ Required secrets:
 ```yaml
 jobs:
   …
-  deploy-branch:
-    needs: format-lint-and-unit-tests
-    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml@v1
+  uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__js__build-and-deploy.yml@v1
     with:
-      cloudfront_distribution_id: E26N41SPUCWIRP
-      cloudfront_paths: /
-      build_script_name: build-staging
-      aws_bucket: s3://hua-mod-web.staging.la.welt.de/${{ github.head_ref || github.ref_name }}
-      build_directory: build
-      branch_deploy: true
-      branch_name: ${{ github.head_ref || github.ref_name }}
-      branch_deploy_base_url: https://hua-mod-web.staging.la.welt.de
+      build_script_name: <the name of the packages build script, ususally "build">
+      deploy_script_name: <the name of the packages deploy script, ususally "deploy">
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
       AWS_ACCESS_KEY_SECRET: ${{ secrets.access_key_secret }}
+      NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
       LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
 ```
 


### PR DESCRIPTION
## What does this change?

Removes slack from being part of the deploy workflow

## Why?

ncluding the slack notification was a not so great idea. By integrating
it in the deploy workflow we will not be notified when any other steps
fail. Therefore pulling it out again.

