### PR TITLE
[LA-2272] Update github actions

### DIFF
--- a/.github/workflows/reusable-workflow__aws-remove-bucket.yaml
+++ b/.github/workflows/reusable-workflow__aws-remove-bucket.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           npm run clean --if-present
           npm run ${{ inputs.build_script_name }}
       - name: Configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -76,7 +76,7 @@ jobs:
           npm run clean --if-present
           npm run ${{ inputs.build_script_name }}
       - name: Configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml
+++ b/.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml
@@ -35,9 +35,9 @@ jobs:
       - name: Send failure message to Slack
         if: inputs.success == false
         id: slack-failure
-        uses: slackapi/slack-github-action@v1.17.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: 't_loyalty_notifications'
+          channel-id: "t_loyalty_notifications"
           payload: |
             {
               "blocks": [
@@ -76,9 +76,9 @@ jobs:
       - name: Send success message to Slack
         if: inputs.success == true
         id: slack-success
-        uses: slackapi/slack-github-action@v1.17.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: 't_loyalty_notifications'
+          channel-id: "t_loyalty_notifications"
           payload: |
             {
               "blocks": [


### PR DESCRIPTION
## What does this change?

Updates dependant actions to versions that do not use node 12 internally.

## Why?

Node 12 for actions is EOL soon.

## Link to supporting ticket or Screenshots (if applicable)

https://axelspringer.atlassian.net/browse/LA-2272
