### PR TITLE
[Chore]: Adjust Deploy S3 Workflow to use dedicated prop for comment PR

### DIFF
--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: false
+      comment_branch_link:
+        required: false
+        type: boolean
+        default: false
       branch_name:
         required: false
         type: string
@@ -86,7 +90,7 @@ jobs:
       - name: Invalidate cloudfront cache
         run: aws cloudfront create-invalidation --distribution-id=${{ inputs.cloudfront_distribution_id }} --paths ${{ inputs.cloudfront_paths }}
       - name: Comment branch link on PR
-        if: inputs.branch_deploy == true
+        if: inputs.comment_branch_link == true
         uses: mshick/add-pr-comment@v1
         with:
           message: "Your branch has been deployed to: ${{ inputs.branch_deploy_base_url }}/${{ inputs.branch_name }}/"

--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -26,7 +26,7 @@ on:
       comment_branch_link:
         required: false
         type: boolean
-        default: false
+        default: true
       branch_name:
         required: false
         type: string
@@ -90,7 +90,7 @@ jobs:
       - name: Invalidate cloudfront cache
         run: aws cloudfront create-invalidation --distribution-id=${{ inputs.cloudfront_distribution_id }} --paths ${{ inputs.cloudfront_paths }}
       - name: Comment branch link on PR
-        if: inputs.comment_branch_link == true
+        if: inputs.comment_branch_link == true && inputs.branch_deploy == true
         uses: mshick/add-pr-comment@v1
         with:
           message: "Your branch has been deployed to: ${{ inputs.branch_deploy_base_url }}/${{ inputs.branch_name }}/"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Required variables to pass in
 
 If using it for branch based deploy you also need to pass in:
 
-- `branch_deploy` (boolean) – Whether the deploy should be branch based (post a comment to the PR after the deploy and sets environment variables when building to set the paths properly in projects)
+- `branch_deploy` (boolean) – Whether the deploy should be branch based (sets environment variables when building to set the paths properly in projects)
+- `comment_branch_link` (boolean) - Wether the branch link should be posted as a comment to the PR after the deploy
 - `branch_name` – the name of the current branch
 - `branch_deploy_base_url` – The base url for the deployed branches
 


### PR DESCRIPTION
## What does this change?
This introduces the `comment_branch_link` property.  When this boolean is set, the branch link will be added to the PR. 

## Why?
I wanted to add shared workflows in the CI pipeline for paperboy-web:
https://github.com/spring-media/la-paperboy-web/pull/180

I stumbled across the following problem: 
I do not want to use the default comment branch link command from the shared workflow because we have a custom message in la-paperboy-web because of the different brands we support in this project. I disabled `branch_deploy`. This leads to not posting the comment, but this leads to the problem that  the environment variables when building for set the paths in projects will not be set. The links in the above mentioned PR are not working. 

My idea was to decouple the linking part from the branch based deployment property. We could release a new version.

I am not sure if this is a good way, i was just thinking if we can adjust the workflow here to move more and more projects to shared workflows. I only want to start a discussion what other people are thinking about this.
