### PR TITLE
Integrate Snyk Github actions

### DIFF
--- a/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
+++ b/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
@@ -1,4 +1,4 @@
-name: Check ulnerabilities
+name: Check vulnerabilities
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
+++ b/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Snyk
         uses: snyk/actions/setup@master
 
-      - name: Run synk test
-        run: synk test --severity-threshold=${{ inputs.severity-threshold }}
+      - name: Run snyk test
+        run: snyk test --severity-threshold=${{ inputs.severity-threshold }}
         env:
           SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}

--- a/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
+++ b/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
@@ -1,0 +1,55 @@
+name: Check ulnerabilities
+
+on:
+  workflow_call:
+    inputs:
+      # With this option, only vulnerabilities of the specified level or higher are reported.
+      severity-threshold:
+        required: false
+        type: string
+        default: low
+    secrets:
+      ACCESS_KEY_ID:
+        required: true
+      ACCESS_KEY_SECRET:
+        required: true
+      LA_SNYK_TOKEN:
+        required: true
+
+jobs:
+  check-vulnerabilities:
+    name: Check for vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Configure AWS creds
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ACCESS_KEY_SECRET }}
+          aws-region: eu-central-1
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ inputs.go_version }}
+
+      - name: Restore go modules cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install Snyk
+        uses: snyk/actions/setup@master
+
+      - name: Run synk test
+        run: synk test --severity-threshold=${{ inputs.severity-threshold }}
+        env:
+          SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}

--- a/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
+++ b/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: string
         default: low
+      go-version:
+        required: true
+        type: string
     secrets:
       ACCESS_KEY_ID:
         required: true
@@ -34,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Restore go modules cache
         uses: actions/cache@v3

--- a/.github/workflows/reusable-workflow__js__check-vulnerabilities.yml
+++ b/.github/workflows/reusable-workflow__js__check-vulnerabilities.yml
@@ -1,0 +1,49 @@
+name: Check vulnerabilities
+
+on:
+  workflow_call:
+    inputs:
+      # With this option, only vulnerabilities of the specified level or higher are reported.
+      severity-threshold:
+        required: false
+        type: string
+        default: low
+
+    secrets:
+      NPM_AUTH_TOKEN:
+        required: true
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+      LA_SNYK_TOKEN:
+        required: true
+
+jobs:
+  check-vulnerabilities:
+    name: Check Vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          always-auth: true
+          cache: npm
+          registry-url: "https://registry.npmjs.org/"
+      - name: Setup npmrc
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.LA_TECH_USER_AUTH_TOKEN}}" >> .npmrc
+          echo "@spring-media:registry=https://npm.pkg.github.com" >> .npmrc
+        env:
+          LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      - name: Install Snyk
+        uses: snyk/actions/setup@master
+      - name: Run synk test
+        run: synk test --severity-threshold=${{ inputs.severity-threshold }}
+        env:
+          SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -211,11 +211,13 @@ jobs:
     uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml@v1
     with:
       severity-threshold: <vulnerabilities threshold not required and default value is low>
+      go-version: <the go version of the project>
     secrets:
       ACCESS_KEY_ID: ${{ secrets.access_key_id }}
       ACCESS_KEY_SECRET: ${{ secrets.access_key_secret }}
       LA_SNYK_TOKEN : ${{secrets.LA_SNYK_TOKEN}}
-
+  …
+```
 
 
 ## golang\_\_format-unit-tests

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Please refer to githubs documentation on how to use and implement shared workflo
 - [aws-remove-bucket](#aws-remove-bucket)
 - [js\_\_build-and-deploy](#js__build-and-deploy)
 - [js\_\_deploy-to-s3](#js__deploy-to-s3)
+- [js\_\_check-vulnerabilities](#js__check-vulnerabilities)
 - [js\_\_format-lint-test](#js__format-lint-test)
 - [js\_\_run-e2e-tests](#js__run-e2e-tests)
+- [golang\_\_check-vulnerabilities](#golang__check-vulnerabilities)
 - [golang\_\_format-unit-tests](#golang__format-unit-tests)
 - [slack-notify-after-production-deploy](#slack-notify-after-production-deploy)
 
@@ -118,6 +120,36 @@ jobs:
       LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
 ```
 
+
+
+## js\_\_check-vulnerabilities
+
+The [js\_\_check-vulnerabilities](./.github/workflows/reusable-workflow__js__check-vulnerabilities.yml) will install synk and check vulnerabilities on the project:
+
+It requires to secrets to be passed in:
+
+- `NPM_AUTH_TOKEN`
+- `LA_TECH_USER_AUTH_TOKEN`
+- `LA_SNYK_TOKEN`
+
+
+- `severity-threshold`  can be passed as input. It's not required but with this option, only vulnerabilities of the specified level or higher will be checked.
+
+The node version has to be set via a `.node-version` file.
+
+### Usage
+
+```yaml
+jobs:
+  …
+  check-vulnerabilities:
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__js__check-vulnerabilities.yml@v1
+    secrets:
+      NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+      LA_SNYK_TOKEN:  ${{ secrets.LA_SNYK_TOKEN }}
+```
+
 ## js\_\_format-lint-test
 
 The [js\_\_format-lint-test workflow](./.github/workflows/reusable-workflow__js__format-lint-test.yml) will install dependencies and then run these npm commands on the project:
@@ -166,6 +198,25 @@ jobs:
       LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
   …
 ```
+
+## golang\_\_check-vulnerabilities
+
+The [golang\_\_check-vulnerabilities workflow](./.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml) will set up synk and check vulnerabilities on the project.
+### Usage
+
+```yaml
+jobs:
+  …
+  check-vulnerabilities:
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__golang__check-vulnerabilities.yml@v1
+    with:
+      severity-threshold: <vulnerabilities threshold not required and default value is low>
+    secrets:
+      ACCESS_KEY_ID: ${{ secrets.access_key_id }}
+      ACCESS_KEY_SECRET: ${{ secrets.access_key_secret }}
+      LA_SNYK_TOKEN : ${{secrets.LA_SNYK_TOKEN}}
+
+
 
 ## golang\_\_format-unit-tests
 


### PR DESCRIPTION
## What does this change?

integrate synk 
Add `reusable-workflow__golang__check-vulnerabilities.yml`
Add `reusable-workflow__js__check-vulnerabilities.yml`


In the ticket acceptance criteria is;

-  snyk action is integrated in the shared lint/test JS 

-  snyk action is integrated in the shared lint/test golang

But I think this should be either in separate workflow or we have to rename lint/test with check-vulnerabilities/lint/test. I prefer integrate synk in separate workflow. 


**snyk test** command scans your project, tests dependencies for vulnerabilities, and reports how many vulnerabilities are found. The command returns a non-zero exit code which causes a build to fail when run inside of CI environments (depending on how the CI tool is configured).

**snyk monitor** command to create a project on the Snyk website to be continuously monitored for new vulnerabilities. After running this command you see the project by logging in to the website and viewing your projects.


I think I should add `run snyk monitor ` step too, to be informed for new vulnerabilities. What do you think? 

## Why?

integrate synk and get notified about potential security issues 

## Link to supporting ticket or Screenshots (if applicable)
https://axelspringer.atlassian.net/browse/LA-2211