### PR TITLE
[LA-2211] create reusable security workflow

### DIFF
--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -16,6 +16,10 @@ on:
         required: true
       ACCESS_KEY_SECRET:
         required: true
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+      LA_TECH_USER_SSH_KEY:
+        required: true
       LA_SNYK_TOKEN:
         required: true
 
@@ -26,13 +30,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
-
-      - name: Configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ACCESS_KEY_SECRET }}
-          aws-region: eu-central-1
+          fetch-depth: 0 # Entire Git history of the repository will be fetched
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -49,6 +48,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Configure AWS creds
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ACCESS_KEY_SECRET }}
+          aws-region: eu-central-1
+
+      - name: Setup environment to pull dependencies from non public spring-media repository
+        env:
+          SSH_KEY: ${{ secrets.LA_TECH_USER_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          touch  ~/.ssh/id_rsa
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 400  ~/.ssh/id_rsa
+          touch ~/.ssh/config
+          export location=~
+          cat << EOF > ~/.ssh/config
+            Host github.com
+              User git
+              Hostname github.com
+              PreferredAuthentications publickey
+              IdentityFile $location/.ssh/id_rsa
+          EOF
+          git config --global url."https://${{ secrets.LA_TECH_USER_AUTH_TOKEN }}:x-oauth-basic@github.com/spring-media".insteadOf "https://github.com/spring-media"
+
       - name: Install Snyk
         uses: snyk/actions/setup@master
 
@@ -56,11 +81,13 @@ jobs:
         run: snyk test --severity-threshold=${{ inputs.severity-threshold }}
         env:
           SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+          GOPRIVATE: github.com/spring-media/*
 
       - name: Leaked Secrets Scan
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          base: ${{ github.event.repository.default_branch }} # Start scanning from default main branch
           head: HEAD
           extra_args: --debug --only-verified

--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -1,0 +1,66 @@
+name: Security (Check Vulnerabilities and Leaked Secrets Scan)
+
+on:
+  workflow_call:
+    inputs:
+      # With this option, only vulnerabilities of the specified level or higher are reported.
+      severity-threshold:
+        required: false
+        type: string
+        default: low
+      go-version:
+        required: true
+        type: string
+    secrets:
+      ACCESS_KEY_ID:
+        required: true
+      ACCESS_KEY_SECRET:
+        required: true
+      LA_SNYK_TOKEN:
+        required: true
+
+jobs:
+  security:
+    name: Check for vulnerabilities and secret scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Configure AWS creds
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ACCESS_KEY_SECRET }}
+          aws-region: eu-central-1
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Restore go modules cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install Snyk
+        uses: snyk/actions/setup@master
+
+      - name: Run snyk test
+        run: snyk test --severity-threshold=${{ inputs.severity-threshold }}
+        env:
+          SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}
+
+      - name: Leaked Secrets Scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified

--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -7,7 +7,7 @@ on:
       severity-threshold:
         required: false
         type: string
-        default: low
+        default: high # Possible values: low, medium, high, critical
       go-version:
         required: true
         type: string
@@ -75,10 +75,11 @@ jobs:
           git config --global url."https://${{ secrets.LA_TECH_USER_AUTH_TOKEN }}:x-oauth-basic@github.com/spring-media".insteadOf "https://github.com/spring-media"
 
       - name: Install Snyk
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@0.3
 
       - name: Run snyk test
         run: snyk test --severity-threshold=${{ inputs.severity-threshold }}
+        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}

--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -1,0 +1,51 @@
+name: Security (Check Vulnerabilities and Leaked Secrets Scan)
+
+on:
+  workflow_call:
+    inputs:
+      # With this option, only vulnerabilities of the specified level or higher are reported.
+      severity-threshold:
+        required: false
+        type: string
+        default: low
+
+    secrets:
+      NPM_AUTH_TOKEN:
+        required: true
+      LA_TECH_USER_AUTH_TOKEN:
+        required: true
+      LA_SNYK_TOKEN:
+        required: true
+
+jobs:
+  security:
+    name: Check for vulnerabilities and secret scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          always-auth: true
+          cache: npm
+          registry-url: "https://registry.npmjs.org/"
+      - name: Setup npmrc
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.LA_TECH_USER_AUTH_TOKEN}}" >> .npmrc
+          echo "@spring-media:registry=https://npm.pkg.github.com" >> .npmrc
+        env:
+          LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+
+      - name: Leaked Secrets Scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified

--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Snyk
         uses: snyk/actions/setup@master
       - name: Run synk test
-        run: synk test --severity-threshold=${{ inputs.severity-threshold }}
+        run: snyk test --severity-threshold=${{ inputs.severity-threshold }}
         env:
           SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}
 

--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -42,6 +42,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
+      - name: Install Snyk
+        uses: snyk/actions/setup@master
+      - name: Run synk test
+        run: synk test --severity-threshold=${{ inputs.severity-threshold }}
+        env:
+          SNYK_TOKEN: ${{ secrets.LA_SNYK_TOKEN }}
+
       - name: Leaked Secrets Scan
         uses: trufflesecurity/trufflehog@main
         with:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Please refer to githubs documentation on how to use and implement shared workflo
 - [js\_\_deploy-to-s3](#js__deploy-to-s3)
 - [js\_\_format-lint-test](#js__format-lint-test)
 - [js\_\_run-e2e-tests](#js__run-e2e-tests)
+- [golang\_\_security](#golang__security)
 - [golang\_\_format-unit-tests](#golang__format-unit-tests)
 - [slack-notify-after-production-deploy](#slack-notify-after-production-deploy)
 
@@ -166,6 +167,28 @@ jobs:
       LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
   …
 ```
+
+
+## golang\_\_security
+
+ The [golang\_\_security workflow](./.github/workflows/reusable-workflow__golang__security.yml) will set up synk and check vulnerabilities on the project.
+ ### Usage
+
+ ```yaml
+ jobs:
+   …
+   security:
+     uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__golang__security.yml@v1
+     with:
+       severity-threshold: <vulnerabilities threshold not required and default value is low>
+       go-version: <the go version of the project>
+     secrets:
+       ACCESS_KEY_ID: ${{ secrets.access_key_id }}
+       ACCESS_KEY_SECRET: ${{ secrets.access_key_secret }}
+       LA_SNYK_TOKEN : ${{secrets.LA_SNYK_TOKEN}}
+   …
+ ```
+
 
 ## golang\_\_format-unit-tests
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Please refer to githubs documentation on how to use and implement shared workflo
 - [js\_\_build-and-deploy](#js__build-and-deploy)
 - [js\_\_deploy-to-s3](#js__deploy-to-s3)
 - [js\_\_format-lint-test](#js__format-lint-test)
+- [js\_\_security](#js__security)
 - [js\_\_run-e2e-tests](#js__run-e2e-tests)
 - [golang\_\_security](#golang__security)
 - [golang\_\_format-unit-tests](#golang__format-unit-tests)
@@ -148,6 +149,34 @@ jobs:
       NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
       LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
 ```
+
+# js\_\_security
+
+ The [js\_\_security](./.github/workflows/reusable-workflow__js__security.yml) will install synk and check vulnerabilities on the project:
+
+ It requires to secrets to be passed in:
+
+ - `NPM_AUTH_TOKEN`
+ - `LA_TECH_USER_AUTH_TOKEN`
+ - `LA_SNYK_TOKEN`
+
+
+ - `severity-threshold`  can be passed as input. It's not required but with this option, only vulnerabilities of the specified level or higher will be checked.
+
+ The node version has to be set via a `.node-version` file.
+
+ ### Usage
+
+ ```yaml
+ jobs:
+   …
+  security:
+    uses: spring-media/la-shared-github-workflows/.github/workflows/reusable-workflow__js__security.yml@v1
+     secrets:
+       NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+       LA_TECH_USER_AUTH_TOKEN: ${{ secrets.LA_TECH_USER_AUTH_TOKEN }}
+       LA_SNYK_TOKEN:  ${{ secrets.LA_SNYK_TOKEN }}
+ ```
 
 ## js\_\_run-e2e-tests
 


### PR DESCRIPTION
## What does this change?

Create reusable security workflow for go and js.

## Why?

- we don't want leak secrets accidentally.

- get notification for potential security issues


## Link to supporting ticket or Screenshots (if applicable)
https://axelspringer.atlassian.net/browse/LA-2211
https://axelspringer.atlassian.net/browse/LA-2209