### PR TITLE
Update slack workflow example to use html_url variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ jobs:
     with:
       workflow: ${{ github.workflow }}
       repository: ${{ github.repository }}
-      repositoryUrl: ${{ github.event.repository.url }}
+      repositoryUrl: ${{ github.event.repository.html_url }}
       refName: ${{ github.ref_name }}
       success: ${{ needs.<ADD JOB ID>.result == 'success' }}
     secrets:


### PR DESCRIPTION
## What does this change?

Updates the slack workflow example to use html_url variable

## Why?

It was using just `url`, which for one project at least pointed to the api url.

Discovered while working on https://github.com/spring-media/la-interactive-caching/pull/19
