### PR TITLE
fetch all git history

### DIFF
--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Entire Git history of the repository will be fetched
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@0.4.0
         env:


### PR DESCRIPTION
## What does this change?
pass `fetch-depth` to fetch all git history.

## Why?
truffle needs to fetch all history to retrieve latest commit of default(main) branch.
## Link to supporting ticket or Screenshots (if applicable)
