### PR TITLE
use stable trufflehog version

### DIFF
--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -77,7 +77,7 @@ jobs:
           GOPRIVATE: github.com/spring-media/*
 
       - name: Leaked Secrets Scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.63.4
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }} # Start scanning from default main branch

--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           args: --severity-threshold=${{ inputs.snyk-severity-threshold }}
       - name: Leaked Secrets Scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.63.4
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## What does this change?

use trufflehog version

## Why?

we were using main and it's not stable.

## Link to supporting ticket or Screenshots (if applicable)
https://github.com/trufflesecurity/trufflehog/releases/tag/v3.63.4