### PR TITLE
pass current branch as head

### DIFF
--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -81,5 +81,5 @@ jobs:
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }} # Start scanning from default main branch
-          head: HEAD
+          head: ${{ github.ref_name }} # Scan the current branch
           extra_args: --debug --only-verified

--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -31,6 +31,6 @@ jobs:
         uses: trufflesecurity/trufflehog@v3.63.4
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.repository.default_branch }} # Start scanning from default main branch
+          head: ${{ github.ref_name }} # Scan the current branch
           extra_args: --debug --only-verified


### PR DESCRIPTION
## What does this change?

pass current branch as head

## Why?

trufflehog released 3.67.5 https://github.com/trufflesecurity/trufflehog/releases/tag/v3.67.5 and seems it scans all commits of default branch even though we pass head so it should take current branch according to documentation.
https://github.com/trufflesecurity/trufflehog?tab=readme-ov-file#advanced-usage And I was working like that before. S

The error message was misleading us to find to reason of fail https://github.com/spring-media/la-hua-api/actions/runs/7865189320/job/21457831291

I run trufflehog in my local and it shows one of the file no longer exists. (see:  deployments/k8s/dev/postgres-deployment/.dockerconfigjson)
<img width="1510" alt="Screenshot 2024-02-12 at 10 31 54" src="https://github.com/spring-media/la-shared-github-workflows/assets/5072294/2968f2e1-b2df-4344-a116-f0cea9bd2b74">

I tested this solution and it's working. 

## Link to supporting ticket or Screenshots (if applicable)
