### PR TITLE
[LA-2877]: Change Github actions to use node 20

### DIFF
--- a/.github/workflows/reusable-workflow__aws-remove-bucket.yaml
+++ b/.github/workflows/reusable-workflow__aws-remove-bucket.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
+++ b/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
+++ b/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS creds
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Entire Git history of the repository will be fetched
 

--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
           always-auth: true

--- a/.github/workflows/reusable-workflow__js__build-and-deploy.yml
+++ b/.github/workflows/reusable-workflow__js__build-and-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           npm run clean --if-present
           npm run ${{ inputs.build_script_name }}
       - name: Configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
           always-auth: true

--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -80,7 +80,7 @@ jobs:
           npm run clean --if-present
           npm run ${{ inputs.build_script_name }}
       - name: Configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/reusable-workflow__js__format-lint-test.yml
+++ b/.github/workflows/reusable-workflow__js__format-lint-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
           always-auth: true

--- a/.github/workflows/reusable-workflow__js__format-lint-test.yml
+++ b/.github/workflows/reusable-workflow__js__format-lint-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/reusable-workflow__js__run-e2e-tests.yaml
+++ b/.github/workflows/reusable-workflow__js__run-e2e-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/reusable-workflow__js__run-e2e-tests.yaml
+++ b/.github/workflows/reusable-workflow__js__run-e2e-tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
           always-auth: true
@@ -38,7 +38,7 @@ jobs:
           echo "127.0.0.1 local.la.welt.de" | sudo tee -a /etc/hosts
           echo "127.0.0.1 local.la.spring-media.de" | sudo tee -a /etc/hosts
       - name: Run e2e tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: chrome
           command: npm run e2e

--- a/.github/workflows/reusable-workflow__js__run-e2e-tests.yaml
+++ b/.github/workflows/reusable-workflow__js__run-e2e-tests.yaml
@@ -38,7 +38,7 @@ jobs:
           echo "127.0.0.1 local.la.welt.de" | sudo tee -a /etc/hosts
           echo "127.0.0.1 local.la.spring-media.de" | sudo tee -a /etc/hosts
       - name: Run e2e tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           browser: chrome
           command: npm run e2e

--- a/.github/workflows/reusable-workflow__js__security.yml
+++ b/.github/workflows/reusable-workflow__js__security.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Entire Git history of the repository will be fetched
       - name: Run Snyk to check for vulnerabilities


### PR DESCRIPTION
## What does this change?
updates to actions that are using node 20:
- configure-aws-credentials@v4
- actions/checkout@v4
- actions/setup-node@v4
- cypress-io/github-action@v6

## Why?
Node 16 reached end of life and all Github Actions needs to be updated to Node 20.

## Link to supporting ticket or Screenshots (if applicable)
https://axelspringer.atlassian.net/browse/LA-2877