### PR TITLE
LA-3052 Update mshick/add-pr-comment and lackapi/slack-github-action to versions with node.js 20

### DIFF
--- a/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
+++ b/.github/workflows/reusable-workflow__js__deploy-to-s3.yaml
@@ -91,7 +91,7 @@ jobs:
         run: aws cloudfront create-invalidation --distribution-id=${{ inputs.cloudfront_distribution_id }} --paths ${{ inputs.cloudfront_paths }}
       - name: Comment branch link on PR
         if: inputs.comment_branch_link == true && inputs.branch_deploy == true
-        uses: mshick/add-pr-comment@v1
+        uses: mshick/add-pr-comment@v2
         with:
           message: "Your branch has been deployed to: ${{ inputs.branch_deploy_base_url }}/${{ inputs.branch_name }}/"
           allow-repeats: false

--- a/.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml
+++ b/.github/workflows/reusable-workflow__slack-notify-after-production-deploy.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Send failure message to Slack
         if: inputs.success == false
         id: slack-failure
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: "t_loyalty_notifications"
           payload: |
@@ -76,7 +76,7 @@ jobs:
       - name: Send success message to Slack
         if: inputs.success == true
         id: slack-success
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: "t_loyalty_notifications"
           payload: |


### PR DESCRIPTION
## What does this change?
Updates to github actions that use node 20:

- mshick/add-pr-comment@v2
- lackapi/slack-github-action@v1.25.0

## Why?
they were overseen in the previous pr https://github.com/spring-media/la-shared-github-workflows/pull/37

## Link to supporting ticket or Screenshots (if applicable)
https://axelspringer.atlassian.net/browse/LA-3052