### PR TITLE
LA-3052 Update actions/setup-g and actions/cache to node 20

### DIFF
--- a/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
+++ b/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
@@ -32,12 +32,12 @@ jobs:
           aws-region: eu-central-1
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go_version }}
 
       - name: Restore go modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -31,12 +31,12 @@ jobs:
           fetch-depth: 0 # Entire Git history of the repository will be fetched
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
 
       - name: Restore go modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
## What does this change?
Updates to github actions that use node 20:

- actions/setup-go@v5
- actions/cache@v4

## Why?
they are used in backend projects and have outdated actions

## Link to supporting ticket or Screenshots (if applicable)
https://axelspringer.atlassian.net/browse/LA-3052
