### PR TITLE
[FIX]: Remove go cache step

### DIFF
--- a/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
+++ b/.github/workflows/reusable-workflow__golang__format-unit-tests.yml
@@ -36,16 +36,6 @@ jobs:
         with:
           go-version: ${{ inputs.go_version }}
 
-      - name: Restore go modules cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Check go formatting
         run: |
           GOFMT_OUTPUT="$(gofmt -l . 2>&1)"

--- a/.github/workflows/reusable-workflow__golang__security.yml
+++ b/.github/workflows/reusable-workflow__golang__security.yml
@@ -35,16 +35,6 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
-      - name: Restore go modules cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       # When we run snyk test it check go.mod file and list all dependencies and go through on all packages.
       # We have private repos that's why we need this step.
       - name: Setup environment to pull dependencies from non public spring-media repository


### PR DESCRIPTION
## What does this change?
This removes the go-cache step. With the newest setup-go we do not need to have this extra step.

## Why?

https://medium.com/@s0k0mata/github-actions-and-go-the-new-cache-feature-in-actions-setup-go-v4-and-what-to-watch-out-for-aeea373ed07d
https://github.com/actions/setup-go/tree/v4?tab=readme-ov-file#caching-dependency-files-and-build-outputs

